### PR TITLE
Added Callable Interface

### DIFF
--- a/src/Utils/Callable.php
+++ b/src/Utils/Callable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OSN\Framework\Utils;
+
+/**
+ * Makes an object invokable or callable.
+ *
+ * @author smalldev2 <smalldev2@onesoftnet.ml>
+ * @package OSN\Framework\Utils
+ */
+interface Callable
+{
+    /**
+     * The invoke magic method.
+     *
+     * @return mixed
+     */
+    public function __invoke();
+}


### PR DESCRIPTION
Added `Callable` interface which has an `__invoke()` method. And now we don't need to use `method_exists($obj, "__invoke")` type syntax to check if the object is invokable/callable; just implement the interface and use `instanceof` operator.