### PR TITLE
Added a bunch of new methods in Query Builder

### DIFF
--- a/src/Core/Database.php
+++ b/src/Core/Database.php
@@ -60,6 +60,7 @@ class Database
         $this->dsn = $dsn;
         $this->dbname = $env["DB_NAME"];
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
     }
 
     public function getVendor(): ?string

--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -265,6 +265,17 @@ abstract class Model implements JsonSerializable
         return $this->patch()->execute();
     }
 
+    public static function query(string $sql = ''): bool|\PDOStatement|Query|Table
+    {
+        $instance = new static();
+
+        if ($sql !== '') {
+            return (new Query())->raw(str_replace('{table}', $instance->table, $sql));
+        }
+
+        return $instance->_table;
+    }
+
     public function __call($name, $args)
     {
         if ($name === 'insert') {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -33,4 +33,14 @@ class Query
     {
         return $this->getQuery();
     }
+
+    public function raw(string $sql): bool|\PDOStatement
+    {
+        return $this->db->query($sql);
+    }
+
+    public function rawFetch(string $sql, int $flags = \PDO::FETCH_ASSOC): array
+    {
+        return $this->raw($sql)->fetchAll($flags);
+    }
 }


### PR DESCRIPTION
Added a bunch of new methods in Query Builder.
List:

+ `selectRaw()`
+ `whereLike()`
+ `orWhereLike()`
+ `andWhereLike()`
+ `union()`
+ `having()`
+ `orHaving()`
+ `rightJoin()`
+ `innerJoin()`
+ `crossJoin()`
+ `joinRaw()`
+ `leftJoinRaw()`
+ `rightJoinRaw()`
+ `innerJoinRaw()`
+ `crossJoinRaw()`

- New feature: Yes
- Fixed bugs: No
- Related Issues/Pull Requests: None 
- Closes: None
